### PR TITLE
John/stats median

### DIFF
--- a/streams-kafka/src/test/java/io/kipe/streams/kafka/processors/expressions/stats/StatsBuilderMedianTest.java
+++ b/streams-kafka/src/test/java/io/kipe/streams/kafka/processors/expressions/stats/StatsBuilderMedianTest.java
@@ -196,4 +196,31 @@ class StatsBuilderMedianTest extends AbstractGenericRecordProcessorTopologyTest 
         assertEquals("A", r.getString("group"));
         assertEquals(20, r.getNumber("myMedian").intValue());
     }
+
+    @Test
+    void testDuplicateElements() {
+        send(GenericRecord.create().with("group", "A").with("field", 10));
+        send(GenericRecord.create().with("group", "A").with("field", 10));
+        send(GenericRecord.create().with("group", "A").with("field", 20));
+        send(GenericRecord.create().with("group", "A").with("field", 20));
+
+        assertEquals(4, this.targetTopic.getQueueSize());
+
+        GenericRecord r = this.targetTopic.readValue();
+        assertEquals("A", r.getString("group"));
+        assertEquals(10, r.getNumber("myMedian").intValue());
+
+        r = this.targetTopic.readValue();
+        assertEquals("A", r.getString("group"));
+        assertEquals(10, r.getNumber("myMedian").intValue());
+
+        r = this.targetTopic.readValue();
+        assertEquals("A", r.getString("group"));
+        assertEquals(10, r.getNumber("myMedian").intValue());
+
+        r = this.targetTopic.readValue();
+        assertEquals("A", r.getString("group"));
+        assertEquals(15, r.getNumber("myMedian").intValue());
+    }
+
 }


### PR DESCRIPTION
This PR introduces the Median class, which calculates the median of a given data stream. During the development process, three different implementations were considered:

**Sorting-based approach**: This implementation sorts the entire data stream whenever the median is requested. While simple, it has a high time complexity of O(n log n) for sorting and O(1) for median computation. It could be more efficient for large data streams or frequent median computations.

**TreeSet and HashMap approach**: This implementation maintains a balanced binary search tree (TreeSet) for storing the data stream elements and a HashMap to store the counts of each element. The time complexity for insertions and deletions is O(log n), while the median computation is O(log n). The space complexity is O(n), but the implementation is more complex due to the additional HashMap.

**Two-heap approach**: This implementation uses two heaps (min heap and max heap) to store the data stream elements. It maintains a balanced partition between the heaps, resulting in a time complexity of O(log n) for insertions and deletions and an efficient O(1) time complexity for median computation. The space complexity is also O(n), and the implementation is more straightforward than the TreeSet and HashMap approach.

After evaluating the three implementations, I chose the two-heap approach for the Median class. The main reasons are its efficient O(1) time complexity for median computation, its simplicity compared to the TreeSet and HashMap approach, and its balanced performance for insertions, deletions, and median computations. This implementation provides a robust and efficient solution for calculating the median of a data stream.