### PR TITLE
stats: add standard deviation expression

### DIFF
--- a/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/expressions/stats/StandardDeviation.java
+++ b/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/expressions/stats/StandardDeviation.java
@@ -1,3 +1,20 @@
+/*
+ * Kipes SDK for Kafka - The High-Level Event Processing SDK.
+ * Copyright © 2023 kipe.io
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package io.kipe.streams.kafka.processors.expressions.stats;
 
 import io.kipe.streams.kafka.processors.StatsExpression;

--- a/streams-kafka/src/test/java/io/kipe/streams/kafka/processors/expressions/stats/StatsBuilderStandardDeviationTest.java
+++ b/streams-kafka/src/test/java/io/kipe/streams/kafka/processors/expressions/stats/StatsBuilderStandardDeviationTest.java
@@ -1,3 +1,20 @@
+/*
+ * Kipes SDK for Kafka - The High-Level Event Processing SDK.
+ * Copyright © 2023 kipe.io
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package io.kipe.streams.kafka.processors.expressions.stats;
 
 import io.kipe.streams.kafka.processors.AbstractGenericRecordProcessorTopologyTest;


### PR DESCRIPTION
In this PR, we introduce sample (stdev) and population (stdevp) standard deviation expressions to the StatsBuilder class. The StatsBuilderStandardDeviationTest class has been updated with relevant test cases to ensure proper functionality.