### PR TITLE
stats: add field documentation

### DIFF
--- a/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/expressions/stats/Average.java
+++ b/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/expressions/stats/Average.java
@@ -21,6 +21,15 @@ import io.kipe.streams.kafka.processors.StatsExpression;
 
 /**
  * The Average class calculates the average value of a specified field within a dataset.
+ * <p>
+ * The fields for this statistical expression are as follows:
+ * <pre>
+ * | field | internal | type    | description                                         |
+ * |-------|----------|---------|-----------------------------------------------------|
+ * | avg   | no       | double  | the calculated average value of the measured field  |
+ * | sum   | yes      | double  | the running sum of the values in the measured field |
+ * | count | yes      | integer | the running count of values in the measured field   |
+ * </pre>
  */
 public class Average extends StatsExpression {
 

--- a/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/expressions/stats/Count.java
+++ b/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/expressions/stats/Count.java
@@ -30,6 +30,13 @@ import io.kipe.streams.kafka.processors.StatsExpression;
  * and if it is not present, it defaults to 1.
  * <p>
  * The class also provides a static factory method count() to retrieve the singleton instance.
+ * <p>
+ * The fields for this statistical expression are as follows:
+ * <pre>
+ * | field | internal | type | description                             |
+ * |-------|----------|------|-----------------------------------------|
+ * | count | no       | long | the count of records in the data stream |
+ * </pre>
  */
 public class Count extends StatsExpression {
 

--- a/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/expressions/stats/DistinctCount.java
+++ b/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/expressions/stats/DistinctCount.java
@@ -24,6 +24,14 @@ import java.util.Set;
 
 /**
  * The DistinctCount class counts distinct values of a specified field in a data stream.
+ * <p>
+ * The fields for this statistical expression are as follows:
+ * <pre>
+ * | field         | internal | type           | description                                              |
+ * |---------------|----------|----------------|----------------------------------------------------------|
+ * | distinctCount | no       | integer        | the count of distinct values at the measured value field |
+ * | values        | yes      | set of objects | the unique values of the specified field                 |
+ * </pre>
  */
 public class DistinctCount extends StatsExpression {
 

--- a/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/expressions/stats/First.java
+++ b/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/expressions/stats/First.java
@@ -21,6 +21,13 @@ import io.kipe.streams.kafka.processors.StatsExpression;
 
 /**
  * The First class is a stats expression that returns the first seen value of records for a specified field.
+ * <p>
+ * The fields for this statistical expression are as follows:
+ * <pre>
+ * | field | internal | type   | description                                      |
+ * |-------|----------|--------|--------------------------------------------------|
+ * | first | no       | object | the first seen value at the measured value field |
+ * </pre>
  */
 public class First extends StatsExpression {
 

--- a/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/expressions/stats/Last.java
+++ b/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/expressions/stats/Last.java
@@ -21,6 +21,13 @@ import io.kipe.streams.kafka.processors.StatsExpression;
 
 /**
  * The Last class is a stats expression that returns the last seen value of records for a specified field.
+ * <p>
+ * The fields for this statistical expression are as follows:
+ * <pre>
+ * | field | internal | type   | description                                     |
+ * |-------|----------|--------|-------------------------------------------------|
+ * | last  | no       | object | the last seen value at the measured value field |
+ * </pre>
  */
 public class Last extends StatsExpression {
 

--- a/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/expressions/stats/Max.java
+++ b/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/expressions/stats/Max.java
@@ -21,6 +21,13 @@ import io.kipe.streams.kafka.processors.StatsExpression;
 
 /**
  * Stats expression to find the maximum value.
+ * <p>
+ * The fields for this statistical expression are as follows:
+ * <pre>
+ * | field | internal | type   | description                             |
+ * |-------|----------|--------|-----------------------------------------|
+ * | max   | no       | double | the maximum value of the measured field |
+ * </pre>
  */
 public class Max extends StatsExpression {
 

--- a/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/expressions/stats/Min.java
+++ b/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/expressions/stats/Min.java
@@ -21,6 +21,13 @@ import io.kipe.streams.kafka.processors.StatsExpression;
 
 /**
  * Stats expression to find the minimum value.
+ * <p>
+ * The fields for this statistical expression are as follows:
+ * <pre>
+ * | field | internal | type   | description                             |
+ * |-------|----------|--------|-----------------------------------------|
+ * | min   | no       | double | the minimum value of the measured field |
+ * </pre>
  */
 public class Min extends StatsExpression {
 

--- a/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/expressions/stats/Mode.java
+++ b/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/expressions/stats/Mode.java
@@ -28,6 +28,14 @@ import java.util.stream.Collectors;
 /**
  * The Mode class calculates the mode of values in a data stream by finding the most frequently occurring value(s) in a
  * specified field.
+ * <p>
+ * The fields for this statistical expression are as follows:
+ * <pre>
+ * | field  | internal | type                     | description                                      |
+ * |--------|----------|--------------------------|--------------------------------------------------|
+ * | mode   | no       | set of strings           | the mode of values at the measured value field   |
+ * | counts | yes      | map of string to integer | the frequency of each unique value               |
+ * </pre>
  */
 public class Mode extends StatsExpression {
 

--- a/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/expressions/stats/Range.java
+++ b/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/expressions/stats/Range.java
@@ -22,6 +22,15 @@ import io.kipe.streams.kafka.processors.StatsExpression;
 /**
  * The Range class calculates the range of values in a data stream by finding the difference between the maximum and
  * minimum values of a specified field.
+ * <p>
+ * The fields for this statistical expression are as follows:
+ * <pre>
+ * | field | internal | type   | description                                          |
+ * |-------|----------|--------|------------------------------------------------------|
+ * | range | no       | double | the calculated range of values in the measured field |
+ * | min   | yes      | double | the minimum value found in the measured field        |
+ * | max   | yes      | double | the maximum value found in the measured field        |
+ * </pre>
  */
 public class Range extends StatsExpression {
     public static final String DEFAULT_FIELD = "range";

--- a/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/expressions/stats/StandardDeviation.java
+++ b/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/expressions/stats/StandardDeviation.java
@@ -25,6 +25,16 @@ import org.apache.kafka.streams.errors.StreamsException;
  * for better numerical stability.
  * <p>
  * Note that an Exception will be thrown if a null field value is encountered during processing.
+ * <p>
+ * The fields for this statistical expression are as follows:
+ * <pre>
+ * | field           | internal | type   | description                                                  |
+ * |-----------------|----------|--------|--------------------------------------------------------------|
+ * | stdev or stdevp | no       | double | the standard deviation of values at the measured value field |
+ * | count           | yes      | double | the number of values processed                               |
+ * | mean            | yes      | double | the running mean of the values                               |
+ * | ssd             | yes      | double | the running sum of squared differences from the mean         |
+ * </pre>
  */
 public class StandardDeviation extends StatsExpression {
     public static final String DEFAULT_SAMPLE_STDEV_FIELD = "stdev";

--- a/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/expressions/stats/Sum.java
+++ b/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/expressions/stats/Sum.java
@@ -30,6 +30,13 @@ import io.kipe.streams.kafka.processors.StatsExpression;
  * and if it is not present, it defaults to 0.
  * <p>
  * The class also provides a static factory method sum(..) to retrieve an instance.
+ * <p>
+ * The fields for this statistical expression are as follows:
+ * <pre>
+ * | field | internal | type   | description                                        |
+ * |-------|----------|--------|----------------------------------------------------|
+ * | sum   | no       | double | the calculated sum of values in the measured field |
+ * </pre>
  */
 public class Sum extends StatsExpression {
 


### PR DESCRIPTION
The PR adds field documentation to our stat expressions. 

While writing this PR, I noted that we need to make subsequence changes:
- Change count types to Long (applicable to mode, stdev, average, distinct count)
- Refactor comments to make them more concise (applicable to sum, count)