### PR TITLE
test context: Add create topic methods with custom serde support

### DIFF
--- a/streams-kafka-test/src/main/java/io/kipe/streams/test/kafka/TopologyTestContext.java
+++ b/streams-kafka-test/src/main/java/io/kipe/streams/test/kafka/TopologyTestContext.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 
+import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.streams.*;
 import org.apache.kafka.streams.Topology.AutoOffsetReset;
 import org.apache.kafka.streams.kstream.Consumed;
@@ -159,7 +160,7 @@ public class TopologyTestContext {
 	// ------------------------------------------------------------------------
 
     /**
-     * Creates a {@link TestInputTopic} for the given topic, key type, and value type.
+     * Creates a {@link TestInputTopic} for the given topic, key type, and value type using JSON serialization.
      * The TopologyTestDriver must be initialized by calling 'initTopologyTestDriver()' before this method is called.
      *
      * @param topic     The name of the topic to create the TestInputTopic for.
@@ -179,7 +180,29 @@ public class TopologyTestContext {
 	}
 
     /**
-     * Creates a {@link TestOutputTopic} for the given topic, key type, and value type.
+     * Creates a {@link TestInputTopic} for the given topic, key serde, and value serde.
+     * The TopologyTestDriver must be initialized by calling 'initTopologyTestDriver()' before this method is called.
+     * This method provides more flexibility in choosing custom serdes for keys and values.
+     *
+     * @param topic The name of the topic to create the TestInputTopic for.
+     * @param key   The serde for the key to be serialized.
+     * @param value The serde for the value to be serialized.
+     * @param <K>   The type of the key.
+     * @param <V>   The type of the value.
+     * @return The created TestInputTopic.
+     * @throws NullPointerException If the TopologyTestDriver has not been initialized.
+     */
+
+	public <K,V> TestInputTopic<K,V> createTestInputTopic(String topic, Serde<K> key, Serde<V> value) {
+		Objects.requireNonNull(this.driver, "TopologyTestDriver must be initialized before by calling 'initTopologyTestDriver()'");
+		return this.driver.createInputTopic(
+				topic,
+				key.serializer(),
+				value.serializer());
+	}
+
+    /**
+     * Creates a {@link TestOutputTopic} for the given topic, key type, and value type using JSON serialization.
      * The TopologyTestDriver must be initialized by calling 'initTopologyTestDriver()' before this method is called.
      *
      * @param topic     The name of the topic to create the TestOutputTopic for.
@@ -196,6 +219,27 @@ public class TopologyTestContext {
 				topic, 
 				JSONSERDEREGISTRY.getDeserializer(keyType), 
 				JSONSERDEREGISTRY.getDeserializer(valueType));
+	}
+
+    /**
+     * Creates a {@link TestOutputTopic} for the given topic, key serde, and value serde.
+     * The TopologyTestDriver must be initialized by calling 'initTopologyTestDriver()' before this method is called.
+     * This method provides more flexibility in choosing custom serdes for keys and values.
+     *
+     * @param topic The name of the topic to create the TestOutputTopic for.
+     * @param key   The serde for the key to be deserialized.
+     * @param value The serde for the value to be deserialized.
+     * @param <K>   The type of the key.
+     * @param <V>   The type of the value.
+     * @return The created TestOutputTopic.
+     * @throws NullPointerException If the TopologyTestDriver has not been initialized.
+     */
+	public <K,V> TestOutputTopic<K,V> createTestOutputTopic(String topic, Serde<K> key, Serde<V> value) {
+		Objects.requireNonNull(this.driver, "TopologyTestDriver must be initialized before by calling 'initTopologyTestDriver()'");
+		return this.driver.createOutputTopic(
+				topic,
+				key.deserializer(),
+				value.deserializer());
 	}
 
     /**


### PR DESCRIPTION
This PR introduces new overloaded methods for `createTestInputTopic` and `createTestOutputTopic` that accept custom serdes as parameters. This enhancement allows users to work with other serialization formats such as Avro or Protocol Buffers, in addition to the existing JSON serialization support.

The changes include:

- Adding `createTestInputTopic(String topic, Serde<K> key, Serde<V> value)` and `createTestOutputTopic(String topic, Serde<K> key, Serde<V> value)` methods.
- Updating documentation for existing methods to indicate that they use JSON serialization.

These changes provide greater flexibility and ease of use for testing Kafka Streams topologies with different serialization formats.