### PR TITLE
added workflow to generate documentation

### DIFF
--- a/.github/workflows/publish-docusite.yaml
+++ b/.github/workflows/publish-docusite.yaml
@@ -1,0 +1,30 @@
+name: Publish Retype powered documentation to GitHub Pages
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - jens/github-pages
+
+jobs:
+  publish:
+    name: Publish documentation site
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Generate documentation site
+        uses: retypeapp/action-build@latest
+        with:
+          config: documentation/retype.yml
+        
+      - name: Publish to Github Pages docsite branch
+        uses: retypeapp/action-github-pages@latest
+        with:
+          branch: docsite
+          update-branch: true


### PR DESCRIPTION
I added a GitHub actions workflow to publish the retype documentation to GitHub pages.

successful run: https://github.com/kipe-io/kipes-sdk/actions/runs/4768314679/jobs/8477495789
documentation: https://kipe-io.github.io/kipes-sdk/

Please note, this PR is just about enabling automated publishing. It's not about cool documentation ;)
