### PR TITLE
processors: add documentation and stateful cmd table for sub-builders

### DIFF
--- a/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/BinBuilder.java
+++ b/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/BinBuilder.java
@@ -55,6 +55,16 @@ import io.kipe.streams.recordtypes.GenericRecord;
  * to be binned is specified using the .field("price") method, the bin span is set with .span(10), and the name of the
  * new field is defined with .newField("price_bin"). Finally, the .build() method is called to construct the topology
  * for the binning operation, which returns a KipesBuilder object.
+ * <p>
+ * The table below shows the available BinBuilder commands with their stateful and internal topics details:
+ * <pre>
+ * | Command  | Stateful | Internal Topics |
+ * |----------|----------|-----------------|
+ * | field    | no       | -               |
+ * | span     | no       | -               |
+ * | newField | no       | -               |
+ * | build    | no       | -               |
+ * </pre>
  *
  * @param <K> the key type.
  */

--- a/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/BinBuilder.java
+++ b/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/BinBuilder.java
@@ -56,14 +56,11 @@ import io.kipe.streams.recordtypes.GenericRecord;
  * new field is defined with .newField("price_bin"). Finally, the .build() method is called to construct the topology
  * for the binning operation, which returns a KipesBuilder object.
  * <p>
- * The table below shows the available BinBuilder commands with their stateful and internal topics details:
+ * The table below shows the bin command with its stateful and internal topics details:
  * <pre>
- * | Command  | Stateful | Internal Topics |
- * |----------|----------|-----------------|
- * | field    | no       | -               |
- * | span     | no       | -               |
- * | newField | no       | -               |
- * | build    | no       | -               |
+ * | command | stateful | internal topics |
+ * |---------|----------|-----------------|
+ * | bin     | no       | -               |
  * </pre>
  *
  * @param <K> the key type.

--- a/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/DedupBuilder.java
+++ b/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/DedupBuilder.java
@@ -64,13 +64,11 @@ import org.slf4j.LoggerFactory;
  * incoming records by their values and configure the deduplication function to use the record values to determine the
  * deduplication group. Finally, we call the build method to set up the stream and start the de-duplication process.
  * <p>
- * The table below shows the available DedupBuilder commands with their stateful and internal topics details:
+ * The table below shows the dedup command with its stateful and internal topics details:
  * <pre>
- * | command   | stateful | internal topics                       |
- * |-----------|----------|---------------------------------------|
- * | groupBy   | no       | -                                     |
- * | advanceBy | no       | -                                     |
- * | emitFirst | yes      | {baseTopicName}-dedup-processor-store |
+ * | command | stateful | internal topics                       |
+ * |---------|----------|---------------------------------------|
+ * | dedup   | yes      | {baseTopicName}-dedup-processor-store |
  * </pre>
  *
  * @param <K>  the incoming and outgoing streams' key type

--- a/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/DedupBuilder.java
+++ b/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/DedupBuilder.java
@@ -68,8 +68,8 @@ import org.slf4j.LoggerFactory;
  * <pre>
  * | command   | stateful | internal topics                       |
  * |-----------|----------|---------------------------------------|
- * | groupBy   | yes      | -                                     |
- * | advanceBy | yes      | -                                     |
+ * | groupBy   | no       | -                                     |
+ * | advanceBy | no       | -                                     |
  * | emitFirst | yes      | {baseTopicName}-dedup-processor-store |
  * </pre>
  *

--- a/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/DedupBuilder.java
+++ b/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/DedupBuilder.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * A Builder to that is used to de-duplicate incoming records. Clients do not instantiate this class directly but use
- * {@link KipesBuilder#stats()}
+ * {@link KipesBuilder#dedup()}
  * <p>
  * The de-duplication process can be configured on two levels:
  * <ol>
@@ -63,6 +63,15 @@ import org.slf4j.LoggerFactory;
  * String. The dedup-topic parameter is the base name for the topics used by the DedupBuilder. Next, we group the
  * incoming records by their values and configure the deduplication function to use the record values to determine the
  * deduplication group. Finally, we call the build method to set up the stream and start the de-duplication process.
+ * <p>
+ * The table below shows the available DedupBuilder commands with their stateful and internal topics details:
+ * <pre>
+ * | command   | stateful | internal topics                       |
+ * |-----------|----------|---------------------------------------|
+ * | groupBy   | yes      | -                                     |
+ * | advanceBy | yes      | -                                     |
+ * | emitFirst | yes      | {baseTopicName}-dedup-processor-store |
+ * </pre>
  *
  * @param <K>  the incoming and outgoing streams' key type
  * @param <V>  the incoming and outgoing streams' value type

--- a/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/EvalBuilder.java
+++ b/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/EvalBuilder.java
@@ -57,12 +57,11 @@ import io.kipe.streams.recordtypes.GenericRecord;
  * to update the "fieldName" field with the value "new-value". Finally, the build method is called to build the topology
  * and return a KipesBuilder object.
  * <p>
- * The table below shows the available EvalBuilder commands with their stateful and internal topics details:
+ * The table below shows the eval command with its stateful and internal topics details:
  * <pre>
  * | command | stateful | internal topics |
  * |---------|----------|-----------------|
- * | with    | no       | -               |
- * | build   | no       | -               |
+ * | eval    | no       | -               |
  * </pre>
  * @param <K> the key type
  */

--- a/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/EvalBuilder.java
+++ b/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/EvalBuilder.java
@@ -56,7 +56,14 @@ import io.kipe.streams.recordtypes.GenericRecord;
  * serdes for the key and value and the base name for the topics. Then, the with method is called to add an expression
  * to update the "fieldName" field with the value "new-value". Finally, the build method is called to build the topology
  * and return a KipesBuilder object.
- *
+ * <p>
+ * The table below shows the available EvalBuilder commands with their stateful and internal topics details:
+ * <pre>
+ * | command | stateful | internal topics |
+ * |---------|----------|-----------------|
+ * | with    | no       | -               |
+ * | build   | no       | -               |
+ * </pre>
  * @param <K> the key type
  */
 public class EvalBuilder<K> extends AbstractTopologyPartBuilder<K, GenericRecord> {

--- a/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/JoinBuilder.java
+++ b/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/JoinBuilder.java
@@ -64,6 +64,17 @@ import org.slf4j.LoggerFactory;
  * (keySerde and valueSerde). The joinBuilder will join the streams with a given window size (Duration.ofDays(1)) and
  * retention period (Duration.ofDays(7)) and use the given valueJoiner function to combine the values of matching keys
  * (value1 + value2). The output of the join operation is written to a topic named "join-output-topic".
+ * <p>
+ * The table below shows the available JoinBuilder commands with their stateful and internal topics details:
+ * <pre>
+ * | Command              | Stateful | Internal Topics                                                     |
+ * |----------------------|----------|---------------------------------------------------------------------|
+ * | withWindowSize       | no       | -                                                                   |
+ * | withWindowSizeBefore | no       | -                                                                   |
+ * | withWindowSizeAfter  | no       | -                                                                   |
+ * | withRetentionPeriod  | no       | -                                                                   |
+ * | as                   | yes      | {topicsBaseName}-join-store-left, {topicsBaseName}-join-store-right |
+ * </pre>
  *
  * @param <K>  key type of both streams
  * @param <V>  value type of the left stream

--- a/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/JoinBuilder.java
+++ b/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/JoinBuilder.java
@@ -65,15 +65,11 @@ import org.slf4j.LoggerFactory;
  * retention period (Duration.ofDays(7)) and use the given valueJoiner function to combine the values of matching keys
  * (value1 + value2). The output of the join operation is written to a topic named "join-output-topic".
  * <p>
- * The table below shows the available JoinBuilder commands with their stateful and internal topics details:
+ * The table below shows the join command with its stateful and internal topics details:
  * <pre>
- * | Command              | Stateful | Internal Topics                                                     |
- * |----------------------|----------|---------------------------------------------------------------------|
- * | withWindowSize       | no       | -                                                                   |
- * | withWindowSizeBefore | no       | -                                                                   |
- * | withWindowSizeAfter  | no       | -                                                                   |
- * | withRetentionPeriod  | no       | -                                                                   |
- * | as                   | yes      | {topicsBaseName}-join-store-left, {topicsBaseName}-join-store-right |
+ * | command | stateful | internal topics                                                     |
+ * |---------|----------|---------------------------------------------------------------------|
+ * | join    | yes      | {topicsBaseName}-join-store-left, {topicsBaseName}-join-store-right |
  * </pre>
  *
  * @param <K>  key type of both streams

--- a/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/SequenceBuilder.java
+++ b/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/SequenceBuilder.java
@@ -78,6 +78,15 @@ import com.fasterxml.jackson.databind.type.CollectionType;
  * The input stream is stream and the topics base name is "topics-base-name". The input records are grouped by the value
  * in the groupBy method and the size of the sequences is set to 5 in the size method. The as method takes a function
  * that aggregates the complete sequence of records for each group key and converts the values to a string.
+ * <p>
+ * The table below shows the available SequenceBuilder commands with their stateful and internal topics details:
+ * <pre>
+ * | Command | Stateful | Internal Topics                           |
+ * |---------|----------|-------------------------------------------|
+ * | groupBy | no       | -                                         |
+ * | size    | no       | -                                         |
+ * | as      | yes      | {topicsBaseName}-sequence-processor-store |
+ * </pre>
  *
  * @param <K>  The type of the key in the input stream
  * @param <V>  The type of the value in the input stream

--- a/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/SequenceBuilder.java
+++ b/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/SequenceBuilder.java
@@ -79,13 +79,11 @@ import com.fasterxml.jackson.databind.type.CollectionType;
  * in the groupBy method and the size of the sequences is set to 5 in the size method. The as method takes a function
  * that aggregates the complete sequence of records for each group key and converts the values to a string.
  * <p>
- * The table below shows the available SequenceBuilder commands with their stateful and internal topics details:
+ * The table below shows the sequence command with its stateful and internal topics details:
  * <pre>
- * | Command | Stateful | Internal Topics                           |
- * |---------|----------|-------------------------------------------|
- * | groupBy | no       | -                                         |
- * | size    | no       | -                                         |
- * | as      | yes      | {topicsBaseName}-sequence-processor-store |
+ * | command  | stateful | internal topics                           |
+ * |----------|----------|-------------------------------------------|
+ * | sequence | yes      | {topicsBaseName}-sequence-processor-store |
  * </pre>
  *
  * @param <K>  The type of the key in the input stream

--- a/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/StatsBuilder.java
+++ b/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/StatsBuilder.java
@@ -77,7 +77,7 @@ import io.kipe.streams.recordtypes.GenericRecord;
  * <pre>
  * | command | stateful | internal topics                  |
  * |---------|----------|----------------------------------|
- * | stats   | yes      | {topicsBaseName}-processor-store |
+ * | stats   | yes      | {topicsBaseName}-stats-processor-store |
  * </pre>
  *
  * @param <K> The key type of the input Kafka topic.

--- a/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/StatsBuilder.java
+++ b/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/StatsBuilder.java
@@ -72,17 +72,12 @@ import io.kipe.streams.recordtypes.GenericRecord;
  * value Serde, and a topic base name "topic-base-name". The statistics expression is then added using the "with"
  * method, with the target field specified as "myCount". Finally, the topology is built with a grouping based on the
  * "group" field, and the output is a KeyValueStore with a key of type "String".
- * 
  * <p>
- * The table below shows the available StatsBuilder commands with their stateful and internal topics details:
+ * The table below shows the stats command with its stateful and internal topics details:
  * <pre>
- * | Command  | Stateful | Internal Topics                  |
- * |----------|----------|----------------------------------|
- * | groupBy  | no       | -                                |
- * | with     | no       | -                                |
- * | as       | no       | -                                |
- * | asKTable | yes      | {topicsBaseName}-processor-store |
- * | build    | yes      | {topicsBaseName}-processor-store |
+ * | command | stateful | internal topics                  |
+ * |---------|----------|----------------------------------|
+ * | stats   | yes      | {topicsBaseName}-processor-store |
  * </pre>
  *
  * @param <K> The key type of the input Kafka topic.

--- a/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/StatsBuilder.java
+++ b/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/StatsBuilder.java
@@ -166,6 +166,8 @@ public class StatsBuilder<K> extends AbstractTopologyPartBuilder<K, GenericRecor
 		}
 		Objects.requireNonNull(getTopicsBaseName(), "topicBaseName");
 
+		final String stateStoreName = getProcessorStoreTopicName(getTopicsBaseName()+"-stats");
+
 		return this.stream
 				
 				.groupBy(
@@ -199,7 +201,7 @@ public class StatsBuilder<K> extends AbstractTopologyPartBuilder<K, GenericRecor
 							return a;
 						},
 						Materialized
-						.<String, GenericRecord, KeyValueStore<Bytes,byte[]>>as(getProcessorStoreTopicName(getTopicsBaseName())) 
+						.<String, GenericRecord, KeyValueStore<Bytes,byte[]>>as(stateStoreName)
 						.withKeySerde(keySerde)
 						.withValueSerde(this.valueSerde)
 						.withCachingDisabled());	// disabled so that incremental aggregates are available

--- a/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/StatsBuilder.java
+++ b/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/StatsBuilder.java
@@ -72,6 +72,18 @@ import io.kipe.streams.recordtypes.GenericRecord;
  * value Serde, and a topic base name "topic-base-name". The statistics expression is then added using the "with"
  * method, with the target field specified as "myCount". Finally, the topology is built with a grouping based on the
  * "group" field, and the output is a KeyValueStore with a key of type "String".
+ * 
+ * <p>
+ * The table below shows the available StatsBuilder commands with their stateful and internal topics details:
+ * <pre>
+ * | Command  | Stateful | Internal Topics                  |
+ * |----------|----------|----------------------------------|
+ * | groupBy  | no       | -                                |
+ * | with     | no       | -                                |
+ * | as       | no       | -                                |
+ * | asKTable | yes      | {topicsBaseName}-processor-store |
+ * | build    | yes      | {topicsBaseName}-processor-store |
+ * </pre>
  *
  * @param <K> The key type of the input Kafka topic.
  */

--- a/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/TableBuilder.java
+++ b/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/TableBuilder.java
@@ -63,11 +63,11 @@ import io.kipe.streams.recordtypes.GenericRecord;
  * streamsBuilder, stream, keySerde and valueSerde as arguments, and the build method is called to create the topology
  * component that groups incoming data by key and stores it in a state store accessible through the transformer.
  * <p>
- * The table below shows the available TableBuilder commands with their stateful and internal topics details:
+ * The table below shows the table command with its stateful and internal topics details:
  * <pre>
- * | Command | Stateful | Internal Topics                               |
+ * | command | stateful | internal topics                               |
  * |---------|----------|-----------------------------------------------|
- * | build   | yes      | {topicsBaseName}-tablebuilder-processor-store |
+ * | table   | yes      | {topicsBaseName}-tablebuilder-processor-store |
  * </pre>
  *
  * @param <K> The key type of the input stream.

--- a/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/TableBuilder.java
+++ b/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/TableBuilder.java
@@ -62,6 +62,13 @@ import io.kipe.streams.recordtypes.GenericRecord;
  * deserialization is defined using the keySerde and valueSerde objects. The TableBuilder is then instantiated with the
  * streamsBuilder, stream, keySerde and valueSerde as arguments, and the build method is called to create the topology
  * component that groups incoming data by key and stores it in a state store accessible through the transformer.
+ * <p>
+ * The table below shows the available TableBuilder commands with their stateful and internal topics details:
+ * <pre>
+ * | Command | Stateful | Internal Topics                               |
+ * |---------|----------|-----------------------------------------------|
+ * | build   | yes      | {topicsBaseName}-tablebuilder-processor-store |
+ * </pre>
  *
  * @param <K> The key type of the input stream.
  */

--- a/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/TableBuilder.java
+++ b/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/TableBuilder.java
@@ -110,7 +110,7 @@ public class TableBuilder<K> extends AbstractTopologyPartBuilder<K, GenericRecor
 		Objects.requireNonNull(resultValueSerde, "resultValueSerde");
 		Objects.requireNonNull(getTopicsBaseName(), "topicsBaseName must be set");
 		
-		final String stateStoreName = getProcessorStoreTopicName(getTopicsBaseName()+"-tablebuilder");
+		final String stateStoreName = getProcessorStoreTopicName(getTopicsBaseName()+"-table");
 		
 		StoreBuilder<KeyValueStore<String, TableRecord<K,GenericRecord>>> tableStoreBuilder =
 				Stores.keyValueStoreBuilder(Stores.persistentKeyValueStore(stateStoreName),

--- a/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/TableBuilder.java
+++ b/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/TableBuilder.java
@@ -67,7 +67,7 @@ import io.kipe.streams.recordtypes.GenericRecord;
  * <pre>
  * | command | stateful | internal topics                               |
  * |---------|----------|-----------------------------------------------|
- * | table   | yes      | {topicsBaseName}-tablebuilder-processor-store |
+ * | table   | yes      | {topicsBaseName}-table-processor-store |
  * </pre>
  *
  * @param <K> The key type of the input stream.

--- a/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/TransactionBuilder.java
+++ b/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/TransactionBuilder.java
@@ -82,15 +82,11 @@ import io.kipe.streams.recordtypes.TransactionRecord;
  * value starts with "start" and ends when the value ends with "end". The emitType is set to {@link EmitType#ALL}, which
  * means that all the records in the transaction will be emitted as TransactionRecords.
  * <p>
- * The table below shows the available TransactionBuilder commands with their stateful and internal topics details:
+ * The table below shows the transaction command with its stateful and internal topics details:
  * <pre>
- * | Command    | Stateful | Internal Topics                              |
- * |------------|----------|----------------------------------------------|
- * | groupBy    | no       | -                                            |
- * | startsWith | no       | -                                            |
- * | endsWith   | no       | -                                            |
- * | emit       | no       | -                                            |
- * | as         | yes      | {topicsBaseName}-transaction-processor-store |
+ * | command     | stateful | internal topics                              |
+ * |-------------|----------|----------------------------------------------|
+ * | transaction | yes      | {topicsBaseName}-transaction-processor-store |
  * </pre>
  *
  * @param <K>  the key type.

--- a/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/TransactionBuilder.java
+++ b/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/TransactionBuilder.java
@@ -81,6 +81,17 @@ import io.kipe.streams.recordtypes.TransactionRecord;
  * used to determine when a transaction starts and ends respectively. In this example, a transaction starts when the
  * value starts with "start" and ends when the value ends with "end". The emitType is set to {@link EmitType#ALL}, which
  * means that all the records in the transaction will be emitted as TransactionRecords.
+ * <p>
+ * The table below shows the available TransactionBuilder commands with their stateful and internal topics details:
+ * <pre>
+ * | Command    | Stateful | Internal Topics                              |
+ * |------------|----------|----------------------------------------------|
+ * | groupBy    | no       | -                                            |
+ * | startsWith | no       | -                                            |
+ * | endsWith   | no       | -                                            |
+ * | emit       | no       | -                                            |
+ * | as         | yes      | {topicsBaseName}-transaction-processor-store |
+ * </pre>
  *
  * @param <K>  the key type.
  * @param <V>  the input value type.

--- a/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/TransformBuilder.java
+++ b/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/TransformBuilder.java
@@ -71,18 +71,11 @@ import org.apache.kafka.streams.kstream.KStream;
  * Finally, we use the changeValue method to specify a transformation function that converts the incoming values from
  * Integer to String, and then use the asKipesBuilder method to build and return the topology.
  * <p>
- * The table below shows the available TransformBuilder commands with their stateful and internal topics details:
+ * The table below shows the transform command with its stateful and internal topics details:
  * <pre>
- * | command        | stateful | internal topics |
- * |----------------|----------|-----------------|
- * | changeValue    | no       | -               |
- * | newValues      | no       | -               |
- * | asValueType    | no       | -               |
- * | changeKey      | no       | -               |
- * | newKeys        | no       | -               |
- * | asKeyType      | no       | -               |
- * | newKeyValues   | no       | -               |
- * | asKeyValueType | no       | -               |
+ * | command   | stateful | internal topics |
+ * |-----------|----------|-----------------|
+ * | transform | no       | -               |
  * </pre>
  *
  * @param <K>  the source stream's key type.

--- a/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/TransformBuilder.java
+++ b/streams-kafka/src/main/java/io/kipe/streams/kafka/processors/TransformBuilder.java
@@ -70,6 +70,20 @@ import org.apache.kafka.streams.kstream.KStream;
  * <p>
  * Finally, we use the changeValue method to specify a transformation function that converts the incoming values from
  * Integer to String, and then use the asKipesBuilder method to build and return the topology.
+ * <p>
+ * The table below shows the available TransformBuilder commands with their stateful and internal topics details:
+ * <pre>
+ * | command        | stateful | internal topics |
+ * |----------------|----------|-----------------|
+ * | changeValue    | no       | -               |
+ * | newValues      | no       | -               |
+ * | asValueType    | no       | -               |
+ * | changeKey      | no       | -               |
+ * | newKeys        | no       | -               |
+ * | asKeyType      | no       | -               |
+ * | newKeyValues   | no       | -               |
+ * | asKeyValueType | no       | -               |
+ * </pre>
  *
  * @param <K>  the source stream's key type.
  * @param <V>  the source stream's value type.


### PR DESCRIPTION
This PR improves the documentation of the sub-builder classes by:

1. Adding detailed class-level Javadoc comments demonstrating how to use the sub-builders and their associated commands.
2. Providing tables of available commands in the sub-builder classes,  specifying whether they are stateful, and listing any associated internal topics.

These changes aim to make the sub-builder classes more understandable and easier to use for developers.

This partially resolves #47. We still need to add docs at the User Guide/Command Reference, which will be done in another pr. 