### PR TITLE
JsonSerdeFactory: Enable automatic module registration for ObjectMapper

### DIFF
--- a/streams-kafka/src/main/java/io/kipe/streams/kafka/factories/JsonSerdeFactory.java
+++ b/streams-kafka/src/main/java/io/kipe/streams/kafka/factories/JsonSerdeFactory.java
@@ -104,7 +104,7 @@ public class JsonSerdeFactory {
 	 * <p>The {@link #close()} method is a no-op in this implementation.
 	 */
 	private static class JsonPOJOSerializer<T> implements Serializer<T> {
-	    private final ObjectMapper objectMapper = new ObjectMapper();
+	    private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
 
 	    /**
 	     * Default constructor needed by Kafka
@@ -164,7 +164,7 @@ public class JsonSerdeFactory {
 	 * The class should be used with Kafka as it includes a default constructor that is needed by Kafka.
 	 */
 	private static class JsonPOJODeserializer<T> implements Deserializer<T> {
-	    private final ObjectMapper objectMapper = new ObjectMapper();
+	    private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
 
 	    private Class<T> tClass;
 


### PR DESCRIPTION
This PR updates the `ObjectMapper` instantiation in both `JsonPOJOSerializer` and `JsonPOJODeserializer` classes to automatically register all available modules on the classpath using the `.findAndRegisterModules()` method. This simplifies the configuration process and makes working with various data formats, libraries, or data types easier without explicitly registering each module.

Changes:
- Update ObjectMapper instantiation in JsonPOJOSerializer class
- Update ObjectMapper instantiation in JsonPOJODeserializer class

Please review the changes and let me know if there are any concerns or suggestions for improvement.